### PR TITLE
Remove slash in WSDL url building

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -181,7 +181,7 @@ class Request
 					'cache_wsdl' => defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? WSDL_CACHE_NONE : WSDL_CACHE_BOTH,
 					'features' => SOAP_SINGLE_ELEMENT_ARRAYS,
 			);
-			$this->soap = new \SoapClient($this->provider->getBaseURL() . '/' . $this->service->getServiceURI(),$options);
+			$this->soap = new \SoapClient($this->provider->getBaseURL() . $this->service->getServiceURI(),$options);
 
 			if ( $this->needsAuthentication ) {
 				$this->soap->__setSoapHeaders(array($this->provider->getAuthentication()->getHeader()));


### PR DESCRIPTION
From https://veritate.tripolis.com//api2/soap/PublishingService?wsdl to https://veritate.tripolis.com/api2/soap/PublishingService?wsdl